### PR TITLE
Fix non-responsive design on the register user page

### DIFF
--- a/training/templates/register_user.html
+++ b/training/templates/register_user.html
@@ -188,7 +188,7 @@
                   <div class="form-group">
                   <label for="id_foss" class="col-lg-4 control-label">FOSS* </label>
                   <div class="col-lg-8">
-                      <div class="form-control" style="font-size:1vw;">{{event_obj.foss}}</div>
+                      <div class="form-control">{{event_obj.foss}}</div>
                   </div>
                   </div>
                   {% if langs %}


### PR DESCRIPTION
The foss text not compatible with the mobile view.
![non-responsive-design](https://github.com/user-attachments/assets/b50506ff-c158-445c-a2f5-bb3461db6924)


Made compatible.