### PR TITLE
Student dashboard

### DIFF
--- a/events/templatetags/eventsdata.py
+++ b/events/templatetags/eventsdata.py
@@ -111,14 +111,16 @@ def can_download_workshop_certificate(key, training):
         return False
     except:
         return 'errors'
+
 def can_enter_test(key, testcode):
     try:
         ta = TestAttendance.objects.get(mdluser_id=key, test_id=testcode)
-    except:
-        return None
-    if ta.status >= 0:
+        mdl = MdlQuizGrades.objects.filter(quiz=ta.mdlquiz_id, userid=key).order_by('-grade').first()
+        if mdl and mdl.grade >= 40:
+            return 3 # test completed with pass grade of 40 or more for given quiz 
         return ta.status
-    return None
+    except TestAttendance.DoesNotExist:
+        return None
 
 def training_file_exits(wid):
     file_path = settings.MEDIA_ROOT + 'training/' + str(wid) + '/' + str(wid) + '.pdf'

--- a/events/views.py
+++ b/events/views.py
@@ -1996,10 +1996,12 @@ def test_list(request, role, status):
             3: SortableHeader('academic__academic_code', True, 'Academic Code'),
             4: SortableHeader('academic', True, 'Institution'),
             5: SortableHeader('organiser', True, 'Organiser'),
-            6: SortableHeader('foss', True, 'FOSS'),
-            7: SortableHeader('tdate', True, 'Date'),
-            8: SortableHeader('Participants', False),
-            9: SortableHeader('', False)
+            6: SortableHeader('invigilator', True, 'Invigilator'),
+            7: SortableHeader('training__department', True, 'Department'),
+            8: SortableHeader('foss', True, 'FOSS'),
+            9: SortableHeader('tdate', True, 'Date'),
+            10: SortableHeader('Participants', False),
+            11: SortableHeader('', False)
         }
         raw_get_data = request.GET.get('o', None)
         collection = get_sorted_list(request, collectionSet, header, raw_get_data)

--- a/mdldjango/templatetags/mdldata.py
+++ b/mdldjango/templatetags/mdldata.py
@@ -33,18 +33,13 @@ def check_test_enrole(rid, mdluser_id):
 def get_participant_mark(rid, mdluser_id):
     try:
         ta = TestAttendance.objects.get(test_id = rid, mdluser_id = mdluser_id)
-    except:
+        if ta.mdlquiz_id:
+            mdl = MdlQuizGrades.objects.filter(quiz = ta.mdlquiz_id, userid = mdluser_id).order_by('-grade').first()
+            if mdl:
+                return round(mdl.grade, 1)
+            return False
+    except TestAttendance.DoesNotExist:
         return False
-    
-    if not ta.mdlquiz_id:
-        return False
-        
-    try:
-        mdlgrade = MdlQuizGrades.objects.get(quiz = ta.mdlquiz_id, userid = mdluser_id)
-    except Exception as e:
-        return False
-        
-    return round(mdlgrade.grade, 1)
 
 def get_moodle_courseid(rid, mdluser_id):
     #print "rid =>", rid

--- a/mdldjango/views.py
+++ b/mdldjango/views.py
@@ -112,7 +112,9 @@ def index(request):
             if category == 2:
                 past_test = Test.objects.filter(id__in = TestAttendance.objects.filter(mdluser_id = mdluser.id).values_list('test_id'), status = 4).order_by('-tdate')
             if category == 4:
-                ongoing_test = Test.objects.filter(Q(status=2)|Q(status=3), academic_id=mdluser.institution, tdate__lte=dt.date.today()).order_by('-tdate')
+                # Display only the tests relevant to the student.
+                tests = TestAttendance.objects.filter(mdluser_id=mdluser.id).values_list('test_id', flat=True)
+                ongoing_test = Test.objects.filter(Q(status=2)|Q(status=3), tdate__lte=dt.date.today(), id__in=tests).order_by('-tdate')
 
             context = {
                 #'p': p,

--- a/mdldjango/views.py
+++ b/mdldjango/views.py
@@ -99,6 +99,7 @@ def index(request):
             past_workshop = None
             past_test = None
             ongoing_test = None
+            tests = TestAttendance.objects.filter(mdluser_id=mdluser.id).values_list('test_id', flat=True)
             if category == 3:
                 upcoming_workshop = []
                 upcoming_workshop = Training.objects.filter((Q(status = 10) | Q(status = 11) | Q(status = 12) |Q(status = 3)), academic_id=mdluser.institution, tdate__lte=dt.date.today()).order_by('-tdate')
@@ -106,15 +107,14 @@ def index(request):
                 #upcoming_workshop.append(up)
                 #p = up.trainingattendance_set.get(mdluser_id=mdluser.id)
             if category == 5:
-                upcoming_test = Test.objects.filter(status=2, academic_id=mdluser.institution, tdate__gt=dt.date.today()).order_by('-tdate')
+                upcoming_test = Test.objects.filter(status=2, id__in=tests, tdate__gt=dt.date.today()).order_by('-tdate')
             if category == 1:
                 past_workshop = TrainingAttend.objects.filter(student__user__email = mdluser.email).order_by('-training__sem_start_date')
             if category == 2:
-                past_test = Test.objects.filter(id__in = TestAttendance.objects.filter(mdluser_id = mdluser.id).values_list('test_id'), status = 4).order_by('-tdate')
+                past_test = Test.objects.filter(id__in=tests, status=4).order_by('-tdate')
             if category == 4:
                 # Display only the tests relevant to the student.
-                tests = TestAttendance.objects.filter(mdluser_id=mdluser.id).values_list('test_id', flat=True)
-                ongoing_test = Test.objects.filter(Q(status=2)|Q(status=3), tdate__lte=dt.date.today(), id__in=tests).order_by('-tdate')
+                ongoing_test = Test.objects.filter(Q(status=2)|Q(status=3), id__in=tests, tdate__lte=dt.date.today()).order_by('-tdate')
 
             context = {
                 #'p': p,

--- a/static/events/templates/test/index.html
+++ b/static/events/templates/test/index.html
@@ -120,6 +120,7 @@
                         <td>{{ record.academic }}</td>
                         <td>{{ record.organiser.user.first_name }}</td>
                         <td>{{ record.invigilator.user.first_name }}</td>
+                        <td>{{ record.training.department.name }}</td>
                         <td>{{ record.foss.foss }}</td>
                         <td>{{ record.tdate|date:"d M Y" }} {{ record.ttime }}</td>
                         {% if status == 'completed' %}

--- a/static/events/templates/test/index.html
+++ b/static/events/templates/test/index.html
@@ -119,6 +119,7 @@
                         <td>{{ record.academic.academic_code}}</td>
                         <td>{{ record.academic }}</td>
                         <td>{{ record.organiser.user.first_name }}</td>
+                        <td>{{ record.invigilator.user.first_name }}</td>
                         <td>{{ record.foss.foss }}</td>
                         <td>{{ record.tdate|date:"d M Y" }} {{ record.ttime }}</td>
                         {% if status == 'completed' %}

--- a/static/mdl/templates/mdluser_index.html
+++ b/static/mdl/templates/mdluser_index.html
@@ -75,12 +75,14 @@
             <table class="table table-striped table-hover table-bordered">
                 <tr>
                     <th>Technology</th>
+                    <th>Test Code</th>
                     <th>Date & Time</th>
                     <th>Score</th>
                 </tr>
                 {% for record in past_test %}
                     <tr>
                         <td>{{ record.foss.foss }}</td>
+                        <td>{{ record.test_code }}</td>
                         <td>{{ record.tdate }} {{ record.ttime }}</td>
                         {% with grade=record.id|get_participant_mark:mdluserid %}
                             {% if grade %}
@@ -148,12 +150,14 @@
             <table class="table table-striped table-hover table-bordered">
                 <tr>
                     <th>Technology</th>
+                    <th>Test Code</th>
                     <th>Date & Time</th>
                     <th>Action</th>
                 </tr>
                 {% for record in ongoing_test %}
                     <tr>
                         <td>{{ record.foss.foss }}</td>
+                        <td>{{ record.test_code }}</td>
                         <td>{{ record.tdate }} {{ record.ttime }}</td>
                         <td>
                             {% with status=mdluserid|can_enter_test:record.id %}
@@ -206,17 +210,17 @@
             <table class="table table-striped table-hover table-bordered">
                 <tr>
                     <th>Technology</th>
-                    <th>Test Code</th>
+                    <!-- <th>Test Code</th> -->
                     <th>Date & Time</th>
-                    <th>Action</th>
+                    <!-- <th>Action</th> -->
                 </tr>
                 {% for record in upcoming_test %}
                     <tr>
                         <td>{{ record.foss.foss }}</td>
                         <td>{{ record.tdate }} {{ record.ttime }}</td>
-                        <td>
-                            <!-- <a href="{% url 'events:student_subscribe' 'test' record.id mdluserid %}">Enroll</a> -->
-                        </td>
+                        <!-- <td>
+                            <a href="{% url 'events:student_subscribe' 'test' record.id mdluserid %}">Enroll</a>
+                        </td> -->
                     </tr>
                 {% endfor %}
             </table>

--- a/static/statistics/templates/online_test.html
+++ b/static/statistics/templates/online_test.html
@@ -131,6 +131,7 @@
               <td>{{ record.academic }}</td>
               <td>{{ record.foss }}</td>
               <td>{{ record.organiser.user.first_name }}</td>
+              <td>{{ record.invigilator.user.first_name }}</td>
               <td>{{ record.tdate|date:"d M Y" }} {{ record.wtime }}</td>
               <td>{{ record.participant_count }}</td>
               <!-- actions based on roles -->

--- a/static/statistics/templates/online_test.html
+++ b/static/statistics/templates/online_test.html
@@ -134,6 +134,7 @@
               <td>{{ record.invigilator.user.first_name }}</td>
               <td>{{ record.tdate|date:"d M Y" }} {{ record.wtime }}</td>
               <td>{{ record.participant_count }}</td>
+              <td>{{ record.training.department.name }}</td>
               <!-- actions based on roles -->
               <td>
                 {%if record.get_test_attendance_count %}

--- a/statistics/views.py
+++ b/statistics/views.py
@@ -329,9 +329,12 @@ def online_test(request):
         4: SortableHeader('academic__institution_name', True, 'Institution'),
         5: SortableHeader('foss__foss', True, 'FOSS'),
         6: SortableHeader('organiser__user__first_name', True, 'Organiser'),
-        7: SortableHeader('tdate', True, 'Date'),
-        8: SortableHeader('participant_count', 'True', 'Participants'),
-        9: SortableHeader('Action', False)
+        7: SortableHeader('invigilator__user__email', True, 'Invigilator'),
+        8: SortableHeader('tdate', True, 'Date'),
+        9: SortableHeader('participant_count', 'True', 'Participants'),
+        10: SortableHeader('training__department__name', True, 'Department'),
+        11: SortableHeader('Action', False)
+        
     }
 
     raw_get_data = request.GET.get('o', None)


### PR DESCRIPTION
Enhance test display logic and scores for student dashboard view

- Show only tests where the student is enrolled, excluding other academic center tests.
- Display test codes for clarity.
- Show test scores if a student has already taken a test for the same FOSS, even when added to a new test.
- Retrieve the maximum grade for a given FOSS for a student.
