### PR TITLE
Updated participant statistics with email, gender, score, and CSV download functionality

### DIFF
--- a/static/statistics/templates/participant.html
+++ b/static/statistics/templates/participant.html
@@ -27,17 +27,29 @@
     </div>
 	<div class="" id="pending">
 		{% if collection %}
+		{% if user|is_invigilator %}
+            <div style="margin-bottom: 15px; display: flex; justify-content: flex-end; gap: 15px;">
+                <a class="btn btn-default" href="{% url 'events:test_participant_ceritificate_all' model.id %}">Download all certificates</a>
+                <a class="btn btn-default" href="{% url 'statistics:statistics_test_participants_csv' model.id %}">Download Participant Data</a>
+            </div>
+		{% endif %}
 		<table class="table table-bordered table-hover table-striped">
 			<tr>
 			    <th>#</th>
 				<th>First Name</th>
 				<th>Last Name</th>
+				<th>Email ID</th>
+				<th>Gender</th>
+				<th>Score</th>
 			</tr>
 			{% for record in collection %}
 				<tr>
-				    <td>{{ forloop.counter }}
+				    <td>{{ forloop.counter }}</td>
 					<td>{{ record.firstname|lower|title }}</td>
 					<td>{{ record.lastname|lower|title }}</td>
+					<td>{{ record.email }}</td>
+					<td>{{ record.gender|title }}</td>
+					<td>{{ record.score }}</td>
 				</tr>
 			{% endfor %}
 		</table>

--- a/static/statistics/templates/training_participant.html
+++ b/static/statistics/templates/training_participant.html
@@ -30,12 +30,14 @@
 			    <th>#</th>
 				<th>First Name</th>
 				<th>Last Name</th>
+				<th>Gender</th>
 			</tr>
 			{% for record in collection %}
 				<tr>
-				    <td>{{ forloop.counter }}
+				    <td>{{ forloop.counter }}</td>
 					<td>{{ record.student.user.first_name }}</td>
 					<td>{{ record.student.user.last_name }}</td>
+					<td>{{ record.student.gender|default:"-"|title }}</td>
 				</tr>
 			{% endfor %}
 		</table>

--- a/statistics/urls.py
+++ b/statistics/urls.py
@@ -18,6 +18,8 @@ urlpatterns =  [ # noqa
     url(r'^online-test/$',  online_test, name="statistics_online_test"),
     url(r'^onlinetest/(?P<rid>\d+)/participants/$',  test_participant,
         name="statistics_test_participants"),
+    url(r'^onlinetest/(?P<rid>\d+)/participants/csv/$',  test_participant_csv,
+        name="statistics_test_participants_csv"),
     url(r'^academic-center/$',  academic_center, name="acdemic_center"),
     url(r'^academic-center/(?P<academic_id>\d+)/$',  academic_center_view,
         name="academic_center_view"),

--- a/statistics/views.py
+++ b/statistics/views.py
@@ -21,7 +21,8 @@ from events.models import *
 from training.models import *
 from creation.models import TutorialResource
 from creation.filters import CreationStatisticsFilter
-from events.views import get_page
+import csv
+from events.views import get_page, is_invigilator
 from .forms import LearnerForm
 from django.core.cache import cache
 from spoken.decorators import rate_limited_view
@@ -401,15 +402,57 @@ def test_participant(request, rid):
     try:
         context['model_label'] = 'Online-Test'
         context['model'] = Test.objects.using('stats').get(id=rid)
-        test_mdlusers = TestAttendance.objects.using('stats').filter(
-            test_id=rid, status__gte=2).values_list('mdluser_id')
-        ids = []
-        for wp in test_mdlusers:
-            ids.append(wp[0])
-        context['collection'] = MdlUser.objects.using('moodle').filter(id__in=ids)
+        test_attendances = TestAttendance.objects.using('stats').filter(
+            test_id=rid, status__gte=2)
+        ids = [ta.mdluser_id for ta in test_attendances]
+        score_dict = {ta.mdluser_id: ta.mdlgrade for ta in test_attendances}
+        collection = MdlUser.objects.using('moodle').filter(id__in=ids)
+        usernames = [u.username for u in collection]
+        students = Student.objects.using('stats').filter(user__username__in=usernames).select_related('user')
+        student_dict = {s.user.username: s.gender for s in students}
+        for u in collection:
+            u.gender = student_dict.get(u.username, '-')
+            u.score = score_dict.get(u.id, '-')
+        context['collection'] = collection
     except Exception:
         raise PermissionDenied()
     return render(request, 'statistics/templates/participant.html', context)
+
+@rate_limited_view
+def test_participant_csv(request, rid):
+    if not rid:
+        raise PermissionDenied()
+    try:
+        if not (request.user.is_authenticated and is_invigilator(request.user)):
+            raise PermissionDenied()
+
+        test = Test.objects.using('stats').get(id=rid)
+        test_attendances = TestAttendance.objects.using('stats').filter(
+            test_id=rid, status__gte=2)
+        ids = [ta.mdluser_id for ta in test_attendances]
+        score_dict = {ta.mdluser_id: ta.mdlgrade for ta in test_attendances}
+        collection = MdlUser.objects.using('moodle').filter(id__in=ids)
+
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="participants_{}.csv"'.format(rid)
+
+        writer = csv.writer(response)
+        writer.writerow(['#', 'First Name', 'Last Name', 'Email ID', 'Score'])
+
+        for index, record in enumerate(collection, start=1):
+            score = score_dict.get(record.id, '-')
+            writer.writerow([
+                index,
+                record.firstname.title(),
+                record.lastname.title(),
+                record.email,
+                score
+            ])
+
+        return response
+
+    except Exception:
+        raise PermissionDenied()
 
 @rate_limited_view
 def academic_center(request, slug=None):


### PR DESCRIPTION
- Added a 'Download Participant Data' link in the test participants page beside 'Download Certificates'. allowing organizers to download participants data as a CSV file
- Updated the "View Participants" table to display columns for Email, Gender, and Score.
- Made it role restricted; only users with 'Invigilator' role can download the participants data.