### PR TITLE
Added download functionality for participant data for online tests

### DIFF
--- a/events/urls.py
+++ b/events/urls.py
@@ -79,6 +79,7 @@ urlpatterns = [
     
     #url(r'^test/subscribe/(\d+)/(\d+)/$',  test_student_subscribe', name='test_student_subscribe'),
     url(r'^test/(\d+)/participant/$',  test_participant, name='test_participant'),
+    url(r'^test/(\d+)/participant/csv/$',  test_participant_csv, name='test_participant_csv'),
     url(r'^test/participant/certificate/(\d+)/(\d+)/$',  test_participant_ceritificate, name='test_participant_ceritificate'),
     url(r'^test/participant/certificate/all/(\d+)/$',  test_participant_ceritificate_all, name='test_participant_ceritificate_all'),
     url(r'^test/(\d+)/attendance/$',  test_attendance, name='test_attendance'),

--- a/events/views.py
+++ b/events/views.py
@@ -2351,6 +2351,49 @@ def test_participant(request, tid=None):
         
         return render(request, 'events/templates/test/test_participant.html', context)
 
+@login_required
+def test_participant_csv(request, tid=None):
+    if not tid:
+        raise PermissionDenied()
+    try:
+        t = Test.objects.get(id=tid)
+    except Exception:
+        raise PermissionDenied()
+
+    if not (t.organiser.user == request.user or (t.invigilator and t.invigilator.user == request.user)):
+        raise PermissionDenied()
+
+    if t.status == 4:
+        test_attendances = TestAttendance.objects.filter(test_id=tid, status__gte=2)
+    else:
+        test_attendances = TestAttendance.objects.filter(test_id=tid)
+
+    response = HttpResponse(content_type='text/csv')
+    response['Content-Disposition'] = 'attachment; filename="participants_{}.csv"'.format(tid)
+    writer = csv.writer(response)
+    writer.writerow(['#', 'First Name', 'Last Name', 'Email ID', 'Score'])
+
+    from mdldjango.models import MdlUser
+    from events.templatetags.eventsdata import get_participant_mark
+
+    for index, record in enumerate(test_attendances, start=1):
+        mdluser = MdlUser.objects.using('moodle').get(id=record.mdluser_id)
+        first_name = record.mdluser_firstname if record.mdluser_firstname else mdluser.firstname
+        last_name = record.mdluser_lastname if record.mdluser_lastname else mdluser.lastname
+        score = get_participant_mark(tid, record.mdluser_id)
+        if not score:
+            score = '-'
+
+        writer.writerow([
+            index,
+            first_name.title(),
+            last_name.title(),
+            mdluser.email,
+            score
+        ])
+
+    return response
+
 def test_participant_ceritificate(request, wid, participant_id):
     #response = HttpResponse(content_type='application/pdf')
     #response['Content-Disposition'] = 'attachment; filename="somefilename.pdf"'

--- a/static/events/templates/test/test_participant.html
+++ b/static/events/templates/test/test_participant.html
@@ -44,8 +44,8 @@
 	<div class="" id="pending">
 		{% if collection %}
         <a style="float: right; padding-right: 9%;" href="{% url 'events:test_participant_ceritificate_all' test.id %}">Download all certificates</a>
-        <a style="float: right; padding-right: 15px;" href="{% url 'events:test_participant_csv' test.id %}">Download Participant Data</a>
-		<table class="table table-striped table-hover table-bordered">
+        <a style="float: left;" href="{% url 'events:test_participant_csv' test.id %}">Download Participant Data</a>
+		<table class="table table-striped table-hover table-bordered" style="clear: both; margin-top: 10px;">
 			<tr>
                 <th>#</th>
 				<th>First Name</th>

--- a/static/events/templates/test/test_participant.html
+++ b/static/events/templates/test/test_participant.html
@@ -43,7 +43,8 @@
     {% endif %}
 	<div class="" id="pending">
 		{% if collection %}
-		<a style="float: right; padding-right: 9%;" href="{% url 'events:test_participant_ceritificate_all' test.id %}">Download all certificates</a>
+        <a style="float: right; padding-right: 9%;" href="{% url 'events:test_participant_ceritificate_all' test.id %}">Download all certificates</a>
+        <a style="float: right; padding-right: 15px;" href="{% url 'events:test_participant_csv' test.id %}">Download Participant Data</a>
 		<table class="table table-striped table-hover table-bordered">
 			<tr>
                 <th>#</th>


### PR DESCRIPTION
- Added a 'Download Participant Data' link in the test participants page beside 'Download Certificates', allowing organizers to download participants data as a CSV file
- Ensures it is role restricted and only invigilators can download the data