### PR TITLE
Updated the certificate issue date fetching logic for swayam csv data export

### DIFF
--- a/training/services.py
+++ b/training/services.py
@@ -218,7 +218,14 @@ def build_swayam_export_rows(event, metadata):
     for index, participant in enumerate(participants, start=1):
         email = (participant.email or '').strip()
         moodle_user = moodle_user_map.get(participant.user_id)
-        moodle_grade = moodle_grade_map.get(moodle_user.id) if moodle_user else None
+        moodle_grade = (
+            MdlQuizGrades.objects.using('moodle')
+            .filter(userid=moodle_user.id, quiz=quiz_id)
+            .order_by('-timemodified')
+            .first()
+            if moodle_user and quiz_id
+            else None
+        )
         final_val = format_ddmmyyyy(dt.datetime.utcfromtimestamp(moodle_grade.timemodified)) if moodle_grade and moodle_grade.timemodified else ''
 
         logger.warning(

--- a/training/templates/ilw_event_list.html
+++ b/training/templates/ilw_event_list.html
@@ -44,7 +44,7 @@
                                 <a href="{% url 'training:event_participants' event.id %}" title="View Participants">View Participants</a>
                                 <br>
                                 {% if today >= event.tdate|default:event.event_end_date %}
-                                    <a href="#" title="Mark Attendance">Mark Attendance</a>
+                                    <a href="{% url 'training:event_attendance' event.id %}" title="Mark Attendance">Mark Attendance</a>
                                 {% else %}
                                     <span title="Available after test date">Mark Attendance</span>
                                 {% endif %}


### PR DESCRIPTION
- Updated the 'Assessment Certificate Issued Date' fetching logic for swayam participant data csv export.
- Now the value for the field is obtained through the mdl_quiz_grades table.
- Also fixed the 'Mark Attendance' link not pointing to correct URL in view ilw swayam events page.