### PR TITLE
Fix duplicate payment attempts check

### DIFF
--- a/donate/payment.py
+++ b/donate/payment.py
@@ -48,15 +48,15 @@ def save_ilw_hdfc_success_data(order_id, data):
 
     #populate participant payee status
     try:
-        payee = Payee.objects.get(transaction__order_id=order_id)
-        logger.warning("save_ilw_hdfc_success_data: Found payee_id=%s for order_id=%s", payee.id, order_id)
-        payee.status = 1 if data.get('status') =='CHARGED' else 2
-        payee.save()
-        logger.warning("save_ilw_hdfc_success_data: Payee status updated to %s", payee.status)
-    except Payee.DoesNotExist:
-        logger.error("save_ilw_hdfc_success_data: Payee matching order_id=%s does not exist", order_id)
-    except Payee.MultipleObjectsReturned:
-        logger.error("save_ilw_hdfc_success_data: Multiple Payees found matching order_id=%s", order_id)
+        payees = Payee.objects.filter(transaction__order_id=order_id)
+        if payees.exists():
+            status_val = 1 if data.get('status') =='CHARGED' else 2
+            for payee in payees:
+                payee.status = status_val
+                payee.save()
+            logger.warning("save_ilw_hdfc_success_data: Payee status updated to %s for all matching payees", status_val)
+        else:
+            logger.error("save_ilw_hdfc_success_data: Payee matching order_id=%s does not exist", order_id)
     except Exception as e:
         logger.exception("save_ilw_hdfc_success_data: Unexpected exception updating payee for order_id=%s", order_id)
 

--- a/training/views.py
+++ b/training/views.py
@@ -869,7 +869,12 @@ class EventAttendanceListView(ListView):
 		
 
 		self.queryset =	main_query.filter(Q(payment_status__status=1)| Q(registartion_type__in=(1,3)) | Q(payment_status__transaction__order_status="CHARGED"))
-		self.unsuccessful_payee = main_query.filter(Q(payment_status__status__in=(0,2)) &  ~Q(payment_status__transaction__order_status="CHARGED")).select_related('payment_status')
+		successful_user_ids = main_query.filter(
+			Q(payment_status__status=1) | 
+			Q(registartion_type__in=(1,3)) | 
+			Q(payment_status__transaction__order_status="CHARGED")
+		).values_list('user_id', flat=True)
+		self.unsuccessful_payee = main_query.filter(Q(payment_status__status__in=(0,2)) &  ~Q(payment_status__transaction__order_status="CHARGED")).exclude(user_id__in=successful_user_ids).select_related('payment_status')
 		if self.event.training_status == 1:
 			self.queryset = main_query.filter(reg_approval_status=1)
 


### PR DESCRIPTION
- Updated the HDFC success status callback logic to handle multiple payee records for the same transaction, resolving MultipleObjectsReturned error for duplicate payment attempts.
- Filters the unsuccessful payee list to ensure students with at least one successful payment or registration do not appear as unpaid.
